### PR TITLE
Add remote-redeploy helper with Docker Manager rebuild and compose modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ sudo bash quick-start.sh
 
 **See [deployment/QUICKSTART.md](deployment/QUICKSTART.md) for complete instructions.**
 
+
+**Option 3: Remote Docker Manager redeploy from your local machine**
+
+```bash
+# Build package, upload to VPS, rebuild image and redeploy via Docker Manager flow
+./scripts/remote-redeploy.sh --mode docker-manager --host <your-vps-ip> --user root --key ~/.ssh/<your-key>
+```
+
+Use `--skip-package` if `cortexbuild_vps_deploy.tar.gz` is already built locally.
+Use `--mode compose` to redeploy with standard Docker Compose.
+
+
 ## 📦 What's Included
 
 ### Core Features

--- a/scripts/remote-redeploy.sh
+++ b/scripts/remote-redeploy.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CortexBuild Pro - Remote VPS redeploy helper
+# Uploads a deployment package and performs a remote rebuild + redeploy.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_SCRIPT="$ROOT_DIR/scripts/create-deployment-package.sh"
+PACKAGE_PATH="$ROOT_DIR/cortexbuild_vps_deploy.tar.gz"
+
+VPS_HOST="${VPS_HOST:-72.62.132.43}"
+VPS_USER="${VPS_USER:-root}"
+VPS_DEPLOY_DIR="${VPS_DEPLOY_DIR:-/root/cortexbuild}"
+SSH_KEY_PATH="${SSH_KEY_PATH:-}"
+SSH_PORT="${SSH_PORT:-22}"
+DEPLOY_MODE="${DEPLOY_MODE:-docker-manager}" # docker-manager|compose
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --host <host>         VPS hostname or IP
+  --user <user>         SSH user (default: root)
+  --dir <remote_dir>    Remote deployment directory (default: /root/cortexbuild)
+  --key <ssh_key>       SSH private key path
+  --port <ssh_port>     SSH port (default: 22)
+  --mode <mode>         Deployment mode: docker-manager | compose (default: docker-manager)
+  --skip-package        Skip creating package (requires local cortexbuild_vps_deploy.tar.gz)
+  -h, --help            Show this help
+
+Environment overrides:
+  VPS_HOST, VPS_USER, VPS_DEPLOY_DIR, SSH_KEY_PATH, SSH_PORT, DEPLOY_MODE
+
+Examples:
+  $(basename "$0") --host 203.0.113.10 --user root --key ~/.ssh/id_rsa
+  $(basename "$0") --mode compose --host 203.0.113.10 --key ~/.ssh/prod
+USAGE
+}
+
+SKIP_PACKAGE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host) VPS_HOST="$2"; shift 2 ;;
+    --user) VPS_USER="$2"; shift 2 ;;
+    --dir) VPS_DEPLOY_DIR="$2"; shift 2 ;;
+    --key) SSH_KEY_PATH="$2"; shift 2 ;;
+    --port) SSH_PORT="$2"; shift 2 ;;
+    --mode) DEPLOY_MODE="$2"; shift 2 ;;
+    --skip-package) SKIP_PACKAGE="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ "$DEPLOY_MODE" != "docker-manager" && "$DEPLOY_MODE" != "compose" ]]; then
+  echo "Invalid --mode: $DEPLOY_MODE (expected docker-manager or compose)" >&2
+  exit 1
+fi
+
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=20 -p "$SSH_PORT")
+if [[ -n "$SSH_KEY_PATH" ]]; then
+  SSH_OPTS+=(-i "$SSH_KEY_PATH")
+fi
+REMOTE="$VPS_USER@$VPS_HOST"
+
+if [[ "$SKIP_PACKAGE" != "true" ]]; then
+  echo "[1/6] Creating deployment package..."
+  "$PACKAGE_SCRIPT"
+fi
+
+echo "[2/6] Verifying local package..."
+if [[ ! -f "$PACKAGE_PATH" ]]; then
+  echo "Deployment package not found: $PACKAGE_PATH" >&2
+  exit 1
+fi
+
+echo "[3/6] Testing SSH connectivity to $REMOTE:$SSH_PORT..."
+ssh "${SSH_OPTS[@]}" "$REMOTE" "echo 'SSH connection OK'"
+
+echo "[4/6] Uploading package to $VPS_DEPLOY_DIR..."
+ssh "${SSH_OPTS[@]}" "$REMOTE" "mkdir -p '$VPS_DEPLOY_DIR'"
+scp "${SSH_OPTS[@]}" "$PACKAGE_PATH" "$REMOTE:$VPS_DEPLOY_DIR/cortexbuild_vps_deploy.tar.gz"
+
+echo "[5/6] Extracting package on VPS..."
+ssh "${SSH_OPTS[@]}" "$REMOTE" "cd '$VPS_DEPLOY_DIR' && rm -rf cortexbuild && tar -xzf cortexbuild_vps_deploy.tar.gz"
+
+echo "[6/6] Rebuilding and redeploying in $DEPLOY_MODE mode..."
+if [[ "$DEPLOY_MODE" == "docker-manager" ]]; then
+  ssh "${SSH_OPTS[@]}" "$REMOTE" "bash -s" <<'EOSSH'
+set -euo pipefail
+cd /root/cortexbuild/cortexbuild/deployment
+
+echo "Building fresh app image (no cache)..."
+docker build --no-cache -t cortexbuild-app:latest -f Dockerfile ..
+
+echo "Tagging backup image..."
+TS=$(date +%Y%m%d_%H%M%S)
+docker tag cortexbuild-app:latest "cortexbuild-app:$TS"
+
+echo "Restarting stack with docker compose..."
+docker compose down || true
+docker compose up -d
+
+echo "Running database migrations..."
+docker compose exec -T app npx prisma migrate deploy
+
+echo "Deployment complete."
+EOSSH
+else
+  ssh "${SSH_OPTS[@]}" "$REMOTE" "bash -s" <<'EOSSH'
+set -euo pipefail
+cd /root/cortexbuild/cortexbuild/deployment
+
+echo "Rebuilding compose services..."
+docker compose build --no-cache app
+docker compose up -d --force-recreate
+
+echo "Running database migrations..."
+docker compose exec -T app npx prisma migrate deploy
+
+echo "Deployment complete."
+EOSSH
+fi
+
+echo "Redeploy succeeded on $REMOTE using mode=$DEPLOY_MODE"


### PR DESCRIPTION
### Motivation
- Provide a non-interactive local helper to build/upload a deployment package and trigger a remote rebuild/redeploy flow that is compatible with the Docker Manager (Portainer) workflow. 
- Make remote redeploy repeatable and configurable for CI/operator usage and support both Docker Manager and standard Docker Compose redeploys.

### Description
- Add `scripts/remote-redeploy.sh`, a non-interactive helper that optionally runs `scripts/create-deployment-package.sh`, verifies `cortexbuild_vps_deploy.tar.gz`, tests SSH connectivity with safe options, uploads the tarball, extracts it on the VPS, and runs a remote rebuild/redeploy. 
- Implement `--mode docker-manager|compose` (default `docker-manager`) so the remote step either rebuilds the image and restarts via the Docker Manager/compose flow or rebuilds/recreates Compose services. 
- Support CLI and environment overrides for `--host`, `--user`, `--dir`, `--key`, `--port`, `--mode`, and `--skip-package` and add validation for invalid modes. 
- Update README deployment section to document the Docker Manager remote redeploy usage and note `--mode compose` as an alternative.

### Testing
- Ran a syntax check with `bash -n scripts/remote-redeploy.sh`, which succeeded. 
- Ran `./scripts/remote-redeploy.sh --help` to verify usage output, which succeeded. 
- Performed an SSH connectivity test from this environment with `ssh -o BatchMode=yes -o ConnectTimeout=10 root@72.62.132.43`, which failed due to `Network is unreachable`, so an end-to-end remote redeploy could not be executed from this runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698999e5dc54832bbb451f5695f5c3c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated remote deployment workflow supporting both docker-manager and Docker Compose deployment modes
  * Includes comprehensive package validation, SSH connectivity verification, and automatic database migrations post-deployment

* **Documentation**
  * Updated Quick Start guide with detailed remote redeployment setup and workflow instructions
  * Added configuration guidance for --skip-package flag and --mode deployment options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->